### PR TITLE
Add support for Vast.ai GPU provider and improve configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Control plane for self-hosted LLM workloads. Manages GPU cloud instances on demand, proxies requests to Ollama and ComfyUI, and exposes a unified REST API for creative and coding features.
 
+For backlog items and progress on issues and new features, please see
+the [Project Board](https://github.com/users/sudosf/projects/2)
+
 ## Prerequisites
 
 - Java 25

--- a/src/main/java/com/zoltraak/gateway/adapters/gpu/VastAiAdapter.java
+++ b/src/main/java/com/zoltraak/gateway/adapters/gpu/VastAiAdapter.java
@@ -1,0 +1,85 @@
+package com.zoltraak.gateway.adapters.gpu;
+
+import com.zoltraak.gateway.adapters.gpu.model.VastAiInstanceWrapper;
+import com.zoltraak.gateway.adapters.gpu.model.VastAiManageRequest;
+import com.zoltraak.gateway.annotations.Adapter;
+import com.zoltraak.gateway.config.properties.OllamaProperties;
+import com.zoltraak.gateway.config.properties.ProviderProperties;
+import com.zoltraak.gateway.domain.enums.PodStatus;
+import com.zoltraak.gateway.domain.shared.PodConnectionDetails;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Adapter
+@ConditionalOnProperty(name = "zoltraak.provider.active", havingValue = "vastai")
+public class VastAiAdapter implements GpuProviderPort {
+    private final ProviderProperties providerProperties;
+    private final WebClient webClient;
+    private final OllamaProperties ollamaProperties;
+
+    public VastAiAdapter(ProviderProperties providerProperties, @Qualifier("providerWebClient") WebClient webClient, OllamaProperties ollamaProperties) {
+        this.providerProperties = providerProperties;
+        this.webClient = webClient;
+        this.ollamaProperties = ollamaProperties;
+    }
+
+    @Override
+    public void start() {
+        changeState("running");
+    }
+
+    @Override
+    public void stop() {
+        changeState("stopped");
+    }
+
+    @Override
+    public PodStatus getStatus() {
+        VastAiInstanceWrapper response = fetchInstance();
+        if (response == null) {
+            throw new IllegalStateException("Could not retrieve instance status from Vast.ai");
+        }
+
+        return switch (response.instances().actualStatus()) {
+            case "running" -> PodStatus.READY;
+            case "loading" -> PodStatus.WARMING;
+            case null -> PodStatus.STARTING;
+            default -> PodStatus.STOPPED;
+        };
+    }
+
+    @Override
+    public PodConnectionDetails getConnectionDetails() {
+        VastAiInstanceWrapper response = fetchInstance();
+        if (response == null) {
+            throw new IllegalStateException("Could not retrieve instance details from Vast.ai");
+        }
+
+        String ipAddress = response.instances().publicIpaddr();
+        String ollamaUrl = "http://%s:%d".formatted(ipAddress, ollamaProperties.getGpuPod().getPort());
+
+        return new PodConnectionDetails(ollamaUrl, null);
+    }
+
+    private VastAiInstanceWrapper fetchInstance() {
+        return webClient
+                .get()
+                .uri("/api/v0/instances/%s".formatted(providerProperties.getVastAi().getInstanceId()))
+                .header("Authorization", "Bearer %s".formatted(providerProperties.getVastAi().getApiKey()))
+                .retrieve()
+                .bodyToMono(VastAiInstanceWrapper.class)
+                .block();
+    }
+
+    private void changeState(String state) {
+        webClient
+                .put()
+                .uri("/api/v0/instances/%s".formatted(providerProperties.getVastAi().getInstanceId()))
+                .header("Authorization", "Bearer %s".formatted(providerProperties.getVastAi().getApiKey()))
+                .bodyValue(new VastAiManageRequest(state))
+                .retrieve()
+                .bodyToMono(Void.class)
+                .block();
+    }
+}

--- a/src/main/java/com/zoltraak/gateway/adapters/gpu/model/VastAiInstanceResponse.java
+++ b/src/main/java/com/zoltraak/gateway/adapters/gpu/model/VastAiInstanceResponse.java
@@ -1,0 +1,11 @@
+package com.zoltraak.gateway.adapters.gpu.model;
+
+import java.util.List;
+
+public record VastAiInstanceResponse(
+        Long id,
+        String actualStatus,
+        String publicIpaddr,
+        List<Integer> ports
+) {
+}

--- a/src/main/java/com/zoltraak/gateway/adapters/gpu/model/VastAiInstanceWrapper.java
+++ b/src/main/java/com/zoltraak/gateway/adapters/gpu/model/VastAiInstanceWrapper.java
@@ -1,0 +1,6 @@
+package com.zoltraak.gateway.adapters.gpu.model;
+
+public record VastAiInstanceWrapper(
+        VastAiInstanceResponse instances
+) {
+}

--- a/src/main/java/com/zoltraak/gateway/adapters/gpu/model/VastAiManageRequest.java
+++ b/src/main/java/com/zoltraak/gateway/adapters/gpu/model/VastAiManageRequest.java
@@ -1,0 +1,10 @@
+package com.zoltraak.gateway.adapters.gpu.model;
+
+public record VastAiManageRequest(
+        String state,
+        String label
+) {
+    public VastAiManageRequest(String state) {
+        this(state, null);
+    }
+}

--- a/src/main/java/com/zoltraak/gateway/annotations/Adapter.java
+++ b/src/main/java/com/zoltraak/gateway/annotations/Adapter.java
@@ -1,0 +1,14 @@
+package com.zoltraak.gateway.annotations;
+
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Component
+public @interface Adapter {
+}

--- a/src/main/java/com/zoltraak/gateway/config/WebClientConfig.java
+++ b/src/main/java/com/zoltraak/gateway/config/WebClientConfig.java
@@ -14,13 +14,12 @@ public class WebClientConfig {
 
     @Bean
     public WebClient providerWebClient(ProviderProperties providerProperties) {
-        // TODO revisit hard-coded timeout (magic number)
-        HttpClient httpClient = HttpClient.create().responseTimeout(Duration.ofSeconds(30));
-        String baseUrl = providerProperties.getActive().equals("vastai")
-                ? providerProperties.getRunPod().getBaseUrl()
-                : providerProperties.getVastAi().getBaseUrl();
+        HttpClient httpClient = HttpClient.create().responseTimeout(Duration.ofSeconds(providerProperties.getTimeoutSeconds()));
 
-        // TODO revisit creating raw instance of client connector
+        String baseUrl = providerProperties.getActive() == GpuProvider.VASTAI
+                ? providerProperties.getVastAi().getBaseUrl()
+                : providerProperties.getRunPod().getBaseUrl();
+
         return WebClient.builder()
                 .clientConnector(new ReactorClientHttpConnector(httpClient))
                 .baseUrl(baseUrl)

--- a/src/main/java/com/zoltraak/gateway/config/WebClientConfig.java
+++ b/src/main/java/com/zoltraak/gateway/config/WebClientConfig.java
@@ -1,6 +1,7 @@
 package com.zoltraak.gateway.config;
 
 import com.zoltraak.gateway.config.properties.ProviderProperties;
+import com.zoltraak.gateway.domain.enums.GpuProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;

--- a/src/main/java/com/zoltraak/gateway/config/properties/OllamaProperties.java
+++ b/src/main/java/com/zoltraak/gateway/config/properties/OllamaProperties.java
@@ -13,11 +13,13 @@ public class OllamaProperties {
     @Data
     public static class GpuPodConfig {
         private String modelVision;
+        private Integer port;
     }
 
     @Data
     public static class LocalConfig {
         private String url;
-        private String timeoutSeconds;
+        private Integer port;
+        private Integer timeoutSeconds;
     }
 }

--- a/src/main/java/com/zoltraak/gateway/config/properties/ProviderProperties.java
+++ b/src/main/java/com/zoltraak/gateway/config/properties/ProviderProperties.java
@@ -1,12 +1,14 @@
 package com.zoltraak.gateway.config.properties;
 
+import com.zoltraak.gateway.domain.enums.GpuProvider;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "zoltraak.provider")
 @Data
 public class ProviderProperties {
-    private String active;
+    private GpuProvider active;
+    private Integer timeoutSeconds;
     private RunPodConfig runPod;
     private VastAiConfig vastAi;
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -24,8 +24,10 @@ zoltraak:
   ollama:
     gpu-pod:
       model-vision: llava:13b # TODO revisit model
+      port: 11434
     local:
-      url: http://localhost:11434
+      url: http://localhost
+      port: 11434
       timeout-seconds: 15
 
   gpu:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,6 +11,7 @@ server:
 zoltraak:
   provider:
     active: vastai
+    timeout-seconds: 30
     vastai:
       api-key: todo
       instance-id: todo


### PR DESCRIPTION
---

### Description
This pull request introduces the following features and improvements:
- Adds a new adapter for integrating with Vast.ai.
- Implements an `@Adapter` annotation for streamlined adapter integration.
- Adds GPU provider models specifically for Vast.ai.
- Introduces a new Ollama GPU provider port.
- Configures a timeout value for providers and refactors hard-coded values for better maintainability.

Additionally, a link to the project board has been added to the documentation for easier navigation.

### Checklist
- [ ] Tests have been added or updated as necessary.
- [ ] Documentation has been updated to reflect the changes.
- [ ] All existing and new code has been reviewed and adheres to project guidelines. 

---