### PR TITLE
Remove Maven dependencies caching step

### DIFF
--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -19,13 +19,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-      - name: Cache Maven dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            maven-${{ runner.os }}-
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2026.1
         with:


### PR DESCRIPTION
Removed caching of Maven dependencies from Qodana workflow.